### PR TITLE
Fix auth password validation

### DIFF
--- a/api/src/services/auth.ts
+++ b/api/src/services/auth.ts
@@ -47,14 +47,6 @@ export class AuthService {
       return null;
     }
 
-    if (data.password === '') {
-      return {
-        userId: user.userId,
-        email: user.email,
-        name: user.name,
-      };
-    }
-
     const isValid = await verify(user.passwordHash, data.password);
     if (!isValid) {
       return null;


### PR DESCRIPTION
## Summary
- remove the early return that allowed empty passwords to bypass verification
- ensure validateCredentials always checks the stored password hash

## Testing
- npm test *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ddf0f0b0832ca1697287b8e1641f