### PR TITLE
Add automated testing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,20 @@
-name: CI
+name: Continuous Integration
 
 on:
   push:
-    branches: ['**']
+    branches:
+      - main
   pull_request:
 
+env:
+  PNPM_VERSION: 9
+  NODE_VERSION: 20
+
 jobs:
-  build-and-test:
+  quality-checks:
+    name: Lint and unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -15,19 +22,30 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-          cache: 'pnpm'
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('package.json', 'api/package.json', 'web/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - name: Install API dependencies
-        run: pnpm --dir api install
+        working-directory: api
+        run: pnpm install --frozen-lockfile=false
 
       - name: Install web dependencies
-        run: pnpm --dir web install
+        working-directory: web
+        run: pnpm install --frozen-lockfile=false
 
       - name: Lint
         run: pnpm lint
@@ -40,6 +58,43 @@ jobs:
 
       - name: Run web unit tests
         run: pnpm test:web
+
+  e2e-smoke-tests:
+    name: End-to-end smoke tests
+    needs: quality-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('package.json', 'api/package.json', 'web/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install API dependencies
+        working-directory: api
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Install web dependencies
+        working-directory: web
+        run: pnpm install --frozen-lockfile=false
 
       - name: Run end-to-end smoke tests
         run: pnpm test:e2e

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ Common workflows are available through pnpm scripts from the repository root:
 - `pnpm test` — execute API unit tests (Redis interactions are mocked).
 - `pnpm test:web` — execute SvelteKit unit/component tests with Vitest.
 - `pnpm test:e2e` — launch the Docker Compose stack (Postgres + Redis + API) and run smoke tests that cover the login/session lifecycle.
+
+## ✅ Continuous Integration
+
+GitHub Actions automatically runs linting, formatting, unit tests, and the Docker-based smoke test workflow for every pull request and pushes to the `main` branch. The workflow definition lives at [`.github/workflows/ci.yml`](.github/workflows/ci.yml).


### PR DESCRIPTION
## Summary
- replace the existing CI workflow with a pnpm-based pipeline that caches dependencies and runs linting, formatting checks, API tests, web tests, and end-to-end smoke tests
- document the new GitHub Actions automation in the README so contributors know what runs on pull requests

## Testing
- pnpm lint
- pnpm test
- pnpm test:web
- pnpm test:e2e *(fails: Docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0cc9ffe0832caf5fee83f5f394af