### PR TITLE
feat(web): surface dns tooling in nav and quick actions

### DIFF
--- a/web/src/lib/components/ToolQuickActions.svelte
+++ b/web/src/lib/components/ToolQuickActions.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { ToolCategory } from '$lib/data/tools';
+
+  export let categories: ToolCategory[] = [];
+
+  function mapLink(category: ToolCategory, link: ToolCategory['links'][number]) {
+    return {
+      ...link,
+      category: category.title,
+    };
+  }
+
+  type QuickAction = ReturnType<typeof mapLink>;
+  let quickActions: QuickAction[] = [];
+
+  $: quickActions = categories.flatMap((category) => category.links.map((link) => mapLink(category, link)));
+</script>
+
+{#if quickActions.length > 0}
+  <section class="mt-6 rounded-2xl border border-surface-200/70 bg-surface-0/40 p-6 shadow-card dark:border-surface-700/60 dark:bg-surface-900/60">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-50">Quick actions</h2>
+        <p class="text-sm text-surface-500 dark:text-surface-400">
+          Jump straight into any tool — including the latest DNS health checks.
+        </p>
+      </div>
+      <a
+        href="/tools"
+        class="inline-flex items-center gap-2 rounded-full border border-surface-200/70 px-3 py-1 text-sm font-medium text-surface-600 transition hover:border-primary-300 hover:text-primary-600 focus:outline-none focus-visible:border-primary-300 focus-visible:text-primary-600 dark:border-surface-700/60 dark:text-surface-200 dark:hover:border-primary-500/40 dark:hover:text-primary-200 dark:focus-visible:border-primary-500/40 dark:focus-visible:text-primary-200"
+      >
+        View all tools
+        <span aria-hidden="true">→</span>
+      </a>
+    </div>
+
+    <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      {#each quickActions as action (action.slug)}
+        <a
+          href={action.href}
+          class="group relative flex flex-col gap-2 rounded-2xl border border-surface-200/70 bg-surface-50/60 p-4 text-left transition hover:border-primary-300 hover:bg-primary-50/70 focus:outline-none focus-visible:border-primary-300 focus-visible:bg-primary-100/60 dark:border-surface-700/60 dark:bg-surface-900/70 dark:hover:border-primary-500/40 dark:hover:bg-primary-500/10 dark:focus-visible:border-primary-500/40 dark:focus-visible:bg-primary-500/20"
+        >
+          <div class="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-primary-600 dark:text-primary-300">
+            <span>{action.category}</span>
+            {#if action.badge}
+              <span class="rounded-full bg-primary-100 px-2 py-0.5 text-[11px] font-semibold tracking-wide text-primary-700 dark:bg-primary-500/20 dark:text-primary-100">
+                {action.badge}
+              </span>
+            {/if}
+          </div>
+          <div class="text-base font-semibold text-surface-900 transition group-hover:text-primary-700 dark:text-surface-50 dark:group-hover:text-primary-100">
+            {action.title}
+          </div>
+          {#if action.description}
+            <p class="text-sm text-surface-500 dark:text-surface-300">{action.description}</p>
+          {/if}
+        </a>
+      {/each}
+    </div>
+  </section>
+{/if}

--- a/web/src/lib/components/layout/AppHeader.svelte
+++ b/web/src/lib/components/layout/AppHeader.svelte
@@ -3,22 +3,93 @@
   import ThemeSwitcher from '$lib/components/ThemeSwitcher.svelte';
   import { auth } from '$lib/api';
   import { goto } from '$app/navigation';
+  import { toolCategories } from '$lib/data/tools';
 
   async function handleLogout() {
     await auth.logout();
     await goto('/auth/login');
+  }
+
+  let mobileMenuOpen = false;
+
+  function closeMobileMenu() {
+    mobileMenuOpen = false;
   }
 </script>
 
 <header
   class="sticky top-0 z-40 border-b border-surface-200/70 bg-surface-50/80 backdrop-blur supports-[backdrop-filter]:bg-surface-50/60 dark:border-surface-700/60 dark:bg-surface-950/80"
 >
-  <div class="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+  <div class="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4 sm:px-6 lg:px-8">
     <a href="/" class="flex items-center gap-3">
       <div class="size-8 rounded-xl preset-filled-primary-500 shadow-card"></div>
       <span class="text-lg font-semibold tracking-tight text-surface-900 dark:text-surface-50">H2Own</span>
     </a>
-    <div class="flex items-center gap-3 text-sm text-surface-600 dark:text-surface-300">
+
+    <nav
+      class="hidden flex-1 items-center justify-center gap-6 text-sm font-medium text-surface-600 dark:text-surface-300 md:flex"
+      aria-label="Primary"
+    >
+      {#each toolCategories as category}
+        <div class="group relative">
+          <a
+            href={`/tools/${category.slug}`}
+            class="flex items-center gap-1 transition hover:text-primary-600 focus:outline-none focus-visible:text-primary-600 dark:hover:text-primary-300 dark:focus-visible:text-primary-300"
+            aria-haspopup="true"
+          >
+            <span>{category.title}</span>
+            <span
+              aria-hidden="true"
+              class="text-xs text-surface-400 transition group-hover:text-primary-500 group-focus-within:text-primary-500 dark:text-surface-500 dark:group-hover:text-primary-300 dark:group-focus-within:text-primary-300"
+            >
+              ▾
+            </span>
+          </a>
+          <div
+            class="pointer-events-none absolute left-1/2 top-full z-30 hidden w-72 -translate-x-1/2 translate-y-3 flex-col gap-3 rounded-2xl border border-surface-200/70 bg-surface-50 p-4 text-left shadow-xl transition group-hover:pointer-events-auto group-hover:flex group-focus-within:pointer-events-auto group-focus-within:flex dark:border-surface-700/60 dark:bg-surface-900"
+          >
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-wide text-surface-500/80 dark:text-surface-400">
+                {category.title}
+              </p>
+              {#if category.description}
+                <p class="mt-1 text-xs text-surface-500 dark:text-surface-400">{category.description}</p>
+              {/if}
+            </div>
+            <div class="flex flex-col gap-2">
+              {#each category.links as link}
+                <a
+                  href={link.href}
+                  class="rounded-xl border border-transparent px-3 py-2 text-sm text-surface-600 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700 focus:outline-none focus-visible:border-primary-300 focus-visible:bg-primary-100/60 focus-visible:text-primary-700 dark:text-surface-200 dark:hover:border-primary-500/40 dark:hover:bg-primary-500/10 dark:hover:text-primary-200 dark:focus-visible:border-primary-500/40 dark:focus-visible:bg-primary-500/20 dark:focus-visible:text-primary-100"
+                >
+                  <div class="flex items-center justify-between gap-3">
+                    <span class="font-semibold text-surface-900 dark:text-surface-100">{link.title}</span>
+                    {#if link.badge}
+                      <span class="rounded-full bg-primary-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-primary-700 dark:bg-primary-500/20 dark:text-primary-200">
+                        {link.badge}
+                      </span>
+                    {/if}
+                  </div>
+                  {#if link.description}
+                    <p class="mt-1 text-xs text-surface-500 dark:text-surface-400">{link.description}</p>
+                  {/if}
+                </a>
+              {/each}
+            </div>
+          </div>
+        </div>
+      {/each}
+    </nav>
+
+    <div class="ml-auto flex items-center gap-3 text-sm text-surface-600 dark:text-surface-300">
+      <button
+        class="rounded-md border border-surface-200/70 px-3 py-1 text-sm font-medium transition hover:border-primary-300 hover:text-primary-600 focus:outline-none focus-visible:border-primary-300 focus-visible:text-primary-600 dark:border-surface-700/60 dark:hover:border-primary-500/40 dark:hover:text-primary-200 dark:focus-visible:border-primary-500/40 dark:focus-visible:text-primary-200 md:hidden"
+        on:click={() => (mobileMenuOpen = !mobileMenuOpen)}
+        aria-expanded={mobileMenuOpen}
+        aria-controls="mobile-nav"
+      >
+        {mobileMenuOpen ? 'Close' : 'Menu'}
+      </button>
       <ThemeSwitcher />
       {#if $page.data.session}
         <span class="hidden sm:inline-block">Hi, {$page.data.session.user.email}</span>
@@ -34,4 +105,46 @@
       {/if}
     </div>
   </div>
+  {#if mobileMenuOpen}
+    <div
+      id="mobile-nav"
+      class="border-t border-surface-200/70 bg-surface-50 py-4 shadow-inner dark:border-surface-700/60 dark:bg-surface-950 md:hidden"
+    >
+      <div class="mx-auto max-w-7xl space-y-6 px-4 sm:px-6">
+        {#each toolCategories as category}
+          <div class="space-y-2">
+            <div>
+              <p class="text-xs font-semibold uppercase tracking-wide text-surface-500/80 dark:text-surface-400">
+                {category.title}
+              </p>
+              {#if category.description}
+                <p class="text-sm text-surface-500 dark:text-surface-400">{category.description}</p>
+              {/if}
+            </div>
+            <div class="space-y-2">
+              {#each category.links as link}
+                <a
+                  href={link.href}
+                  class="block rounded-lg border border-surface-200/70 px-3 py-2 text-sm font-medium text-surface-700 transition hover:border-primary-300 hover:bg-primary-50 hover:text-primary-700 focus:outline-none focus-visible:border-primary-300 focus-visible:bg-primary-100/60 focus-visible:text-primary-700 dark:border-surface-700/60 dark:text-surface-200 dark:hover:border-primary-500/40 dark:hover:bg-primary-500/10 dark:hover:text-primary-200 dark:focus-visible:border-primary-500/40 dark:focus-visible:bg-primary-500/20 dark:focus-visible:text-primary-100"
+                  on:click={closeMobileMenu}
+                >
+                  <div class="flex items-center justify-between gap-3">
+                    <span>{link.title}</span>
+                    {#if link.badge}
+                      <span class="rounded-full bg-primary-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-primary-700 dark:bg-primary-500/20 dark:text-primary-200">
+                        {link.badge}
+                      </span>
+                    {/if}
+                  </div>
+                  {#if link.description}
+                    <p class="mt-1 text-xs text-surface-500 dark:text-surface-400">{link.description}</p>
+                  {/if}
+                </a>
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
 </header>

--- a/web/src/lib/data/tools.ts
+++ b/web/src/lib/data/tools.ts
@@ -1,0 +1,103 @@
+export type ToolLink = {
+  /** Machine readable identifier */
+  slug: string;
+  /** Display label for the link */
+  title: string;
+  /** Target href for the tool */
+  href: string;
+  /** Optional short description shown in menus */
+  description?: string;
+  /** Optional badge text such as "New" */
+  badge?: string;
+};
+
+export type ToolCategory = {
+  /** Machine readable identifier */
+  slug: string;
+  /** Human readable category label */
+  title: string;
+  /** Short helper copy for the category */
+  description?: string;
+  /** Collection of tools that belong to the category */
+  links: ToolLink[];
+};
+
+/**
+ * Structured catalogue of tools surfaced in navigation menus and quick actions.
+ * Keeping this centralised ensures the header menu and front page stay in sync.
+ */
+export const toolCategories: ToolCategory[] = [
+  {
+    slug: 'dns',
+    title: 'DNS',
+    description: 'Domain health and resolver diagnostics',
+    links: [
+      {
+        slug: 'propagation-checker',
+        title: 'DNS Propagation Checker',
+        href: '/tools/dns/propagation-checker',
+        description: 'Track DNS record changes across global resolvers in near real-time.',
+        badge: 'New',
+      },
+      {
+        slug: 'dnssec-sanity-check',
+        title: 'DNSSEC Sanity Check',
+        href: '/tools/dns/dnssec-sanity-check',
+        description: 'Validate DNSSEC chains of trust and spot signing or rollover issues.',
+        badge: 'New',
+      },
+      {
+        slug: 'record-lookup',
+        title: 'DNS Record Lookup',
+        href: '/tools/dns/record-lookup',
+        description: 'Inspect A, AAAA, CNAME, MX and TXT records from authoritative sources.',
+      },
+    ],
+  },
+  {
+    slug: 'performance',
+    title: 'Performance',
+    description: 'Latency and availability checks',
+    links: [
+      {
+        slug: 'http-status',
+        title: 'HTTP Status Inspector',
+        href: '/tools/performance/http-status',
+        description: 'Fetch an endpoint to review status codes, headers and response timing.',
+      },
+      {
+        slug: 'global-ping',
+        title: 'Global Ping Test',
+        href: '/tools/performance/global-ping',
+        description: 'Measure round-trip latency from multiple geographic regions.',
+      },
+    ],
+  },
+  {
+    slug: 'security',
+    title: 'Security',
+    description: 'TLS and application hardening helpers',
+    links: [
+      {
+        slug: 'tls-audit',
+        title: 'TLS Certificate Audit',
+        href: '/tools/security/tls-audit',
+        description: 'Review certificate chains, expiry windows and supported cipher suites.',
+      },
+      {
+        slug: 'headers-check',
+        title: 'Security Headers Check',
+        href: '/tools/security/headers-check',
+        description: 'Analyse HTTP response headers for best-practice security coverage.',
+      },
+    ],
+  },
+];
+
+/** Flattened list of every tool, useful for quick action displays. */
+export const allTools = toolCategories.flatMap((category) =>
+  category.links.map((link) => ({
+    ...link,
+    category: category.title,
+  }))
+);

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -4,6 +4,8 @@
   import PoolSummaryCard from "$lib/components/PoolSummaryCard.svelte";
   import QuickTestForm from "$lib/components/QuickTestForm.svelte";
   import RecommendationsCard from "$lib/components/RecommendationsCard.svelte";
+  import ToolQuickActions from "$lib/components/ToolQuickActions.svelte";
+  import { toolCategories } from "$lib/data/tools";
 
   export let data;
 
@@ -48,6 +50,8 @@
 </script>
 
 <Container>
+  <ToolQuickActions categories={toolCategories} />
+
   {#if data.session}
     <!-- Metrics row -->
     <h2 class="mt-6 text-xl font-semibold text-surface-900 dark:text-surface-50">Last Test Results</h2>


### PR DESCRIPTION
## Summary
- add a shared tool catalogue that now includes the DNS propagation checker and DNSSEC sanity check
- expose the DNS category (and other tools) in the desktop dropdown and mobile versions of the header menu
- render a quick action panel on the home page that lists every tool entry for rapid access

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d34f0a0c84832c8e064d9111b227ae